### PR TITLE
feat: add functions to lookup supervoxel IDs per root ID

### DIFF
--- a/dvid_point_cloud/client.py
+++ b/dvid_point_cloud/client.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import requests
 import ast
 import numpy as np
+from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ class DVIDClient:
             max_voxel=tuple(data["maxvoxel"])
         )
     
-    def get_supervoxels(self, uuid: str, instance: str, body_id: int) -> bytes:
+    def get_supervoxels(self, uuid: str, instance: str, body_id: int) -> NDArray[np.int64]:
         """
         Get supervoxel IDs for a specific body ID.
         """

--- a/dvid_point_cloud/client.py
+++ b/dvid_point_cloud/client.py
@@ -5,6 +5,8 @@ from typing import Any, Dict
 from dataclasses import dataclass
 
 import requests
+import ast
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +78,21 @@ class DVIDClient:
             max_voxel=tuple(data["maxvoxel"])
         )
     
+    def get_supervoxels(self, uuid: str, instance: str, body_id: int) -> bytes:
+        """
+        Get supervoxel IDs for a specific body ID.
+        """
+        url = f"{self.server}/api/node/{uuid}/{instance}/supervoxels/{body_id}"
+        response = self.session.get(url, timeout=self.timeout)
+        response.raise_for_status()
+
+        # convert to array of integers
+        response = response.content.decode('utf-8')
+        response = ast.literal_eval(response)
+        response = np.array(response, dtype=np.int64)
+
+        return response
+
     def get_sparse_vol(self, uuid: str, instance: str, label_id: int, 
                    format: str = "rles", scale: int = 0, supervoxels: bool = False) -> bytes:
         """

--- a/dvid_point_cloud/sampling.py
+++ b/dvid_point_cloud/sampling.py
@@ -220,9 +220,9 @@ def sample_supervoxels(server: str, uuid: str, instance: str, body_id: int):
     Sample supervoxel IDs for a body ID.
     """
     client = DVIDClient(server)
-    response = client.get_supervoxels(uuid, instance, body_id)
+    supervoxel_ids = client.get_supervoxels(uuid, instance, body_id)
 
-    return response
+    return supervoxel_ids
 
 def sample_supervoxels_for_bodies(server: str, uuid: str, instance: str, body_ids: List[int]):
     """

--- a/dvid_point_cloud/sampling.py
+++ b/dvid_point_cloud/sampling.py
@@ -214,6 +214,35 @@ def uniform_sample(server: str, uuid: str, label_id: int,
         return pd.DataFrame(points_xyz, columns=["x", "y", "z"])
     else:
         return points_xyz
+    
+def sample_supervoxels(server: str, uuid: str, instance: str, body_id: int):
+    """
+    Sample supervoxel IDs for a body ID.
+    """
+    client = DVIDClient(server)
+    response = client.get_supervoxels(uuid, instance, body_id)
+
+    return response
+
+def sample_supervoxels_for_bodies(server: str, uuid: str, instance: str, body_ids: List[int]):
+    """
+    Sample supervoxel IDs for multiple bodies.
+    """
+    result = {}
+    for body_id in body_ids:
+        try:
+            supervoxel_ids = sample_supervoxels(server, uuid, instance, body_id)
+
+            # If points were returned (non-empty body), add to result
+            if isinstance(supervoxel_ids, pd.DataFrame) and not supervoxel_ids.empty:
+                result[body_id] = supervoxel_ids
+            elif isinstance(supervoxel_ids, np.ndarray) and supervoxel_ids.shape[0] > 0:
+                result[body_id] = supervoxel_ids
+            
+        except Exception as e:
+            logger.error(f"Error sampling supervoxels for body {body_id}: {e}")
+
+    return result
 
 
 def sample_for_bodies(server: str, uuid: str, instance: str, body_ids: List[int], 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -9,7 +9,7 @@ import pytest
 
 from dvid_point_cloud.client import DVIDClient
 from dvid_point_cloud.parse import parse_rles, rles_to_points
-from dvid_point_cloud.sampling import uniform_sample
+from dvid_point_cloud.sampling import uniform_sample, sample_supervoxels
 
 
 def test_parse_rles(create_sparse_volume):
@@ -62,6 +62,15 @@ def test_rles_to_points():
     # Check that points match expected
     np.testing.assert_array_equal(points, expected)
 
+
+def test_sample_supervoxels():
+    """Test that the label at a point is correctly returned."""
+    server = "https://hemibrain-dvid.janelia.org"
+    uuid = "15aee239283143c08b827177ebee01b3"
+    instance = "segmentation"
+    body_id = 1137590955
+    supervoxels = sample_supervoxels(server, uuid, instance, body_id)
+    assert supervoxels.shape == (4911,)
 
 def test_uniform_sample_integration(mock_server, create_sparse_volume, generate_sparse_volume):
     """Integration test for uniform_sample function."""


### PR DESCRIPTION
I added functionality to retrieve supervoxel IDs based on a given (list) of bodyID(s). @DocSavage, could you please have a look and merge if it looks good? 