### PR TITLE
move DVID label/supervoxel access to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,38 @@ print(json.dumps(layer_json))
 # or use it programmatically with the Neuroglancer Python API
 ```
 
+### Additional helper functions in DVIDClient
+
+First get the client for a particular DVID server:
+
+```python
+client = DVIDClient(server)
+```
+
+Get the label at a point:
+
+```python
+label = client.get_label(uuid, instance, point, supervoxels=supervoxels)  
+```
+
+Get the labels at a list of points:
+
+```python
+response = client.get_labels(uuid, instance, points, supervoxels=supervoxels)  
+```
+
+Get supervoxel ids for a label id:
+
+```python
+supervoxel_ids = client.get_supervoxels(uuid, instance, body_id)
+```
+
+Get supervoxel ids for a list of label ids, returning a dict with label ids as keys:
+
+```python
+dict_of_label_supervoxels = client.get_supervoxels_for_bodies(uuid, instance, [101, 102, 103])
+```
+
 ## Requirements
 
 - Python 3.7+

--- a/dvid_point_cloud/__init__.py
+++ b/dvid_point_cloud/__init__.py
@@ -3,5 +3,5 @@
 __version__ = "0.1.0"
 
 from .client import DVIDClient
-from .sampling import uniform_auto_scale, uniform_sample, sample_for_bodies
+from .sampling import uniform_auto_scale, uniform_sample
 from .neuroglancer import point_cloud_to_neuroglancer_json

--- a/dvid_point_cloud/sampling.py
+++ b/dvid_point_cloud/sampling.py
@@ -216,52 +216,6 @@ def uniform_sample(server: str, uuid: str, label_id: int,
     else:
         return points_xyz
     
-def label_at_point(server: str, uuid: str, instance: str, point: tuple[int, int, int], supervoxels: bool = False) -> int:
-    """
-    Get the label at a specific point.
-    """
-    client = DVIDClient(server)
-    label = client.get_label(uuid, instance, point, supervoxels=supervoxels)  
-
-    return label
-
-def labels_at_points(server: str, uuid: str, instance: str, points: List[List[int]], supervoxels: bool = False) -> List[int]:
-    """
-    Get the labels at a list of points.
-    """
-    client = DVIDClient(server)
-    response = client.get_labels(uuid, instance, points, supervoxels=supervoxels)  
-    return response
-
-def sample_supervoxels(server: str, uuid: str, instance: str, body_id: int):
-    """
-    Sample supervoxel IDs for a body ID.
-    """
-    client = DVIDClient(server)
-    supervoxel_ids = client.get_supervoxels(uuid, instance, body_id)
-
-    return supervoxel_ids
-
-def sample_supervoxels_for_bodies(server: str, uuid: str, instance: str, body_ids: List[int]):
-    """
-    Sample supervoxel IDs for multiple bodies.
-    """
-    result = {}
-    for body_id in body_ids:
-        try:
-            supervoxel_ids = sample_supervoxels(server, uuid, instance, body_id)
-
-            # If points were returned (non-empty body), add to result
-            if isinstance(supervoxel_ids, pd.DataFrame) and not supervoxel_ids.empty:
-                result[body_id] = supervoxel_ids
-            elif isinstance(supervoxel_ids, np.ndarray) and supervoxel_ids.shape[0] > 0:
-                result[body_id] = supervoxel_ids
-            
-        except Exception as e:
-            logger.error(f"Error sampling supervoxels for body {body_id}: {e}")
-
-    return result
-
 def sample_for_bodies(server: str, uuid: str, instance: str, body_ids: List[int], 
                      density_or_count: Union[float, int] = 1000, scale: int = 0,
                      supervoxels: bool = False, output_format: str = "xyz") -> Dict[int, Union[np.ndarray, pd.DataFrame]]:


### PR DESCRIPTION
Since getting supervoxels and labels from DVID server aren't sampling, moved it to DVID client. This also allows removing essentially proxy functions for the access. Added documentation. @jakobtroidl @stuarteberg 